### PR TITLE
Bindingflags only needed in Unity < 5

### DIFF
--- a/Assets/ThirdParty/Spriter2Unity/Editor/Utils/AnimationCurveUtils.cs
+++ b/Assets/ThirdParty/Spriter2Unity/Editor/Utils/AnimationCurveUtils.cs
@@ -189,10 +189,11 @@ namespace Assets.ThirdParty.Spriter2Unity.Editor.Spriter
         public static void SetAnimationSettings(this AnimationClip animClip, AnimationClipSettings settings)
         {
             //Use reflection to get the internal method
-            BindingFlags bindingFlags = BindingFlags.Static | BindingFlags.NonPublic;
+            
 #if UNITY_5
             AnimationUtility.SetAnimationClipSettings(animClip, settings);
 #else
+			BindingFlags bindingFlags = BindingFlags.Static | BindingFlags.NonPublic;
             MethodInfo mInfo = typeof(AnimationUtility).GetMethod("SetAnimationClipSettings", bindingFlags);
             mInfo.Invoke(null, new object[] { animClip, settings });
 #endif


### PR DESCRIPTION
Bindingflags only needed in Unity < 5
